### PR TITLE
Fixes error reported by -Wformat-truncation

### DIFF
--- a/src/liboping.c
+++ b/src/liboping.c
@@ -104,6 +104,7 @@
 #endif
 
 #define PING_ERRMSG_LEN 256
+#define PING_ERRMSG_MESSAGE_LEN (PING_ERRMSG_LEN-50)
 #define PING_TABLE_LEN 5381
 
 struct pinghost
@@ -1641,10 +1642,10 @@ int ping_host_add (pingobj_t *obj, const char *host)
 		}
 		else
 		{
-			char errmsg[PING_ERRMSG_LEN];
+			char errmsg[PING_ERRMSG_MESSAGE_LEN];
 
-			snprintf (errmsg, PING_ERRMSG_LEN, "Unknown `ai_family': %i", ai_ptr->ai_family);
-			errmsg[PING_ERRMSG_LEN - 1] = '\0';
+			snprintf (errmsg, PING_ERRMSG_MESSAGE_LEN, "Unknown `ai_family': %i", ai_ptr->ai_family);
+			errmsg[PING_ERRMSG_MESSAGE_LEN - 1] = '\0';
 
 			dprintf ("%s", errmsg);
 			ping_set_error (obj, "getaddrinfo", errmsg);


### PR DESCRIPTION
liboping.c: In function 'ping_host_add':
liboping.c:207:9: error: '%s' directive output may be truncated writing up to 255 bytes into a region of size 243